### PR TITLE
fix:  Failed to add 'pip0' connection: ipv6.addr-gen-mode: property i…

### DIFF
--- a/roles/host-init/tasks/publicInterface.yml
+++ b/roles/host-init/tasks/publicInterface.yml
@@ -2,5 +2,5 @@
   service: name=NetworkManager state=started enabled=yes
 
 - name: Configure the public network card
-  shell: nmcli connection add type tun ifname pip0 con-name pip0 mode tap ip4 {{ advertise_address }}/32
+  shell: nmcli connection add type tun ifname pip0 con-name pip0 mode tap ip4 {{ advertise_address }}/32 ipv6.ip6-privacy 0 ipv6.addr-gen-mode eui64
   tags: publicNetwork


### PR DESCRIPTION
…s invalid